### PR TITLE
🐛 Fix build error: Remove unused format import

### DIFF
--- a/src/components/BookingStats.tsx
+++ b/src/components/BookingStats.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { CheckCircle, Calendar, Users, Clock } from 'lucide-react';
 import { Booking } from '@/types/booking';
-import { format } from 'date-fns';
 
 interface BookingStatsProps {
   bookings: Booking[];


### PR DESCRIPTION
✅ Remove unused 'format' import from BookingStats.tsx ✅ Build now passes all ESLint checks
✅ Ready for deployment

ESLint error resolved: @typescript-eslint/no-unused-vars